### PR TITLE
CA-768 chrome on iOS is unusable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "twilio-video-app-react",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -23053,9 +23053,9 @@
       }
     },
     "twilio-video": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/twilio-video/-/twilio-video-2.12.0.tgz",
-      "integrity": "sha512-LfR7Z005yYVcWJpkZR39zBYA6PymaQy+AX1q8Ag4eiFP4CqxUcgpf8mGJcIG7kZQevOLXSPnImlt8Od5ButAtg==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/twilio-video/-/twilio-video-2.13.0.tgz",
+      "integrity": "sha512-s+lU6a1eL3zmropDDQu0LaqmBEasrZ34Pr7vftUBsy23oYApEhby54XvPb2+aWkM0vvoOez32jLRjE2YgwQ38A==",
       "requires": {
         "@twilio/webrtc": "4.3.2",
         "backoff": "^2.5.0",
@@ -23123,9 +23123,9 @@
       "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw=="
     },
     "ua-parser-js": {
-      "version": "0.7.23",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.23.tgz",
-      "integrity": "sha512-m4hvMLxgGHXG3O3fQVAyyAQpZzDOvwnhOTjYz5Xmr7r/+LpkNy3vJXdVRWgd1TkAb7NGROZuSy96CrlNVjA7KA=="
+      "version": "0.7.24",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.24.tgz",
+      "integrity": "sha512-yo+miGzQx5gakzVK3QFfN0/L9uVhosXBBO7qmnk7c2iw1IhL212wfA3zbnI54B0obGwC/5NWub/iT9sReMx+Fw=="
     },
     "uglify-es": {
       "version": "3.3.9",

--- a/package.json
+++ b/package.json
@@ -64,8 +64,9 @@
     "serverless-stack-output": "^0.2.3",
     "strip-color": "^0.1.0",
     "twilio": "^3.56.0",
-    "twilio-video": "^2.12.0",
-    "typescript": "^3.9.7"
+    "twilio-video": "^2.13.0",
+    "typescript": "^3.9.7",
+    "ua-parser-js": "^0.7.24"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^4.2.4",

--- a/src/components/MenuBar/ToggleGridViewButton/ToggleGridViewButton.tsx
+++ b/src/components/MenuBar/ToggleGridViewButton/ToggleGridViewButton.tsx
@@ -34,6 +34,7 @@ export default function ToggleGridViewButton() {
     if (forceCollaboration === true) {
       if (width && width >= 768) setForceCollaboration(false);
     }
+    // eslint-disable-next-line
   }, [width, forceCollaboration]);
 
   return forceCollaboration ? null : (

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom';
 import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
 
 import Video, { TwilioError } from 'twilio-video';
+import UAParser from 'ua-parser-js';
 import { CssBaseline } from '@material-ui/core';
 import { MuiThemeProvider } from '@material-ui/core/styles';
 import { ERROR_MESSAGE } from './utils/displayStrings';
@@ -55,9 +56,25 @@ const VideoApp = () => {
   }, []);
 
   if (!Video.isSupported) {
-    return (
-      <ErrorDialog dismissError={() => null} error={(ERROR_MESSAGE.UNSUPPORTED_MESSAGE as unknown) as TwilioError} />
-    );
+    // Please follow the following git issue and remove the following code if chrome on iOS is supported
+    // https://github.com/twilio/twilio-video.js/issues/1388
+    // <<<<<< START
+    const parser = new UAParser();
+    const result = parser.getResult();
+    let allowAnyway = false;
+    const osVer = result.os.version.split('.');
+
+    // forcing "allow" to iOS version 14.4 (for chrome/firefox)
+    if (result.os.name === 'iOS' && Number(osVer[0] || 0) >= 14 && Number(osVer[1] || 0) >= 5) allowAnyway = true;
+
+    if (!allowAnyway)
+      // END >>>>>>>
+      return (
+        <ErrorDialog
+          dismissError={() => null}
+          error={{ message: ERROR_MESSAGE.UNSUPPORTED_MESSAGE as string } as TwilioError}
+        />
+      );
   }
   return (
     <VideoProvider

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom';
 import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
 
 import Video, { TwilioError } from 'twilio-video';
+import UAParser from 'ua-parser-js';
 import { CssBaseline } from '@material-ui/core';
 import { MuiThemeProvider } from '@material-ui/core/styles';
 import { ERROR_MESSAGE } from './utils/displayStrings';
@@ -55,9 +56,25 @@ const VideoApp = () => {
   }, []);
 
   if (!Video.isSupported) {
-    return (
-      <ErrorDialog dismissError={() => null} error={(ERROR_MESSAGE.UNSUPPORTED_MESSAGE as unknown) as TwilioError} />
-    );
+    // Please follow the following git issue and remove the following code if chrome on iOS is supported
+    // https://github.com/twilio/twilio-video.js/issues/1388
+    // <<<<<< START
+    const parser = new UAParser();
+    const result = parser.getResult();
+    let allowAnyway = false;
+    const osVer = result.os.version.split('.');
+
+    // forcing "allow" to iOS version 14.4 (for chrome/firefox)
+    if (result.os.name === 'iOS' && Number(osVer[0] || 0) >= 14 && Number(osVer[1] || 0) >= 4) allowAnyway = true;
+
+    if (!allowAnyway)
+      // END >>>>>>>
+      return (
+        <ErrorDialog
+          dismissError={() => null}
+          error={{ message: ERROR_MESSAGE.UNSUPPORTED_MESSAGE as string } as TwilioError}
+        />
+      );
   }
   return (
     <VideoProvider


### PR DESCRIPTION
Demo:
https://user-images.githubusercontent.com/34302982/110351242-4a217880-803d-11eb-81f6-c6e3439947d7.mp4
1. Seeing the system throws an error when not checking to allow version 14.4 and above (checking 14.5^)
2. Changing the statement to check 14.4 and up, now it works
3. Changing back to 14.5^ and again it won't work
